### PR TITLE
稟議一覧クエリにおけるテーブル結合時のカラムの重複の修正

### DIFF
--- a/pkg/db/sql/budget/select_budget.sql
+++ b/pkg/db/sql/budget/select_budget.sql
@@ -1,1 +1,1 @@
-SELECT BIN_TO_UUID(`budgets`.id) as budget_id, BIN_TO_UUID(proposer_user_id) as user_id, username as user_name, icon_url, `status`, class, name, budget, settlement, updated_at FROM `budgets` LEFT JOIN `user_profiles` ON `budgets`.proposer_user_id = `user_profiles`.user_id;
+SELECT BIN_TO_UUID(`budgets`.id) as budget_id, BIN_TO_UUID(proposer_user_id) as user_id, username as user_name, icon_url, `status`, class, name, budget, settlement, `budgets`.updated_at as updated_at FROM `budgets` LEFT JOIN `user_profiles` ON `budgets`.proposer_user_id = `user_profiles`.user_id;


### PR DESCRIPTION
### 問題
稟議の一覧を取得するクエリを実行した際に、 `Column 'updated_at' in field list is ambiguous` というエラーが出力されてこける

### 考えられる原因
`budgets` テーブルと `user_profiles` テーブルの両方に `updated_at` カラムがある

### やったこと
稟議側( `budgets` )の `updated_at` を残すように指定した

### 補足
当時フロントエンドの稟議一覧ページを並行して作成していたのですが、バックエンド側にこの変更を適用したところ正常に一覧の取得ができるようになりました