### PR TITLE
稟議のsetApprove内で実行するクエリ名の修正

### DIFF
--- a/pkg/budget/put_budget_budget_id_admin.go
+++ b/pkg/budget/put_budget_budget_id_admin.go
@@ -54,14 +54,17 @@ func updateStatus(dbClient db.TransactionClient, budgetId string, status string)
 }
 
 func setApprove(dbClient db.TransactionClient, budgetId string, approverUserId string) *response.Error {
+	status := "approve"
 	params := struct {
 		BudgetId       string `twowaysql:"budgetId"`
 		ApproverUserId string `twowaysql:"approverUserId"`
+		Status         string `twowaysql:"status"`
 	}{
 		BudgetId:       budgetId,
 		ApproverUserId: approverUserId,
+		Status:         status,
 	}
-	_, err := dbClient.Exec("sql/budget/update_budget_status.sql", &params, false)
+	_, err := dbClient.Exec("sql/budget/update_budget_approver.sql", &params, false)
 	if err != nil {
 		return &response.Error{Code: http.StatusInternalServerError, Level: "Error", Message: "不明なエラーが発生しました", Log: err.Error()}
 	}

--- a/pkg/budget/put_budget_budget_id_admin.go
+++ b/pkg/budget/put_budget_budget_id_admin.go
@@ -54,15 +54,12 @@ func updateStatus(dbClient db.TransactionClient, budgetId string, status string)
 }
 
 func setApprove(dbClient db.TransactionClient, budgetId string, approverUserId string) *response.Error {
-	status := "approve"
 	params := struct {
 		BudgetId       string `twowaysql:"budgetId"`
 		ApproverUserId string `twowaysql:"approverUserId"`
-		Status         string `twowaysql:"status"`
 	}{
 		BudgetId:       budgetId,
 		ApproverUserId: approverUserId,
-		Status:         status,
 	}
 	_, err := dbClient.Exec("sql/budget/update_budget_approver.sql", &params, false)
 	if err != nil {

--- a/pkg/db/sql/budget/update_budget_approver.sql
+++ b/pkg/db/sql/budget/update_budget_approver.sql
@@ -1,1 +1,1 @@
-UPDATE budgets SET `status` =  /*status*/'comment', approver_user_id = UUID_TO_BIN(/*approverUserId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'), approved_at = CURRENT_TIMESTAMP WHERE id = UUID_TO_BIN(/*budgetId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+UPDATE budgets SET approver_user_id = UUID_TO_BIN(/*approverUserId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'), approved_at = CURRENT_TIMESTAMP WHERE id = UUID_TO_BIN(/*budgetId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');


### PR DESCRIPTION
### 問題
pkg/budget/put_budget_budget_id_admin.go

`/budget/[budgetId]/admin` に対してbodyが `{status: "approve"}` のリクエストをPOSTすると、`no parameter that matches the bind value: status` というエラーが出力されて処理に失敗する

`{status: "reject"}` の場合は処理に成功したので、approve の場合のみ実行される関数に問題があると考えられます

### 考えられる原因
`setApprove()` 内で処理に使用するクエリについて誤ったものが指定されている
- 誤: `"sql/budget/update_budget_status.sql"`
- 正: `"sql/budget/update_budget_approver.sql"`

(`update_budget_status.sql` は他の関数 `updateStatus()` でも使用されており、またクエリ内のバインド変数と `params` が噛み合っていないので誤ったファイルが指定されていると判断しました)

### やったこと
- `setApprove()` で実行するクエリ名を `"sql/budget/update_budget_approver.sql"` に変更
- 上に伴い、`dbClient.Exec()` に渡す `params` に `{Status: "approve"}` を追加