### PR TITLE
稟議を購入済みにする際に領収書の添付を必須化 (backend)

### DIFF
--- a/pkg/budget/put_budget_budget_id_status_approve.go
+++ b/pkg/budget/put_budget_budget_id_status_approve.go
@@ -23,6 +23,9 @@ func PutBudgetBudgetIdStatusApprove(ctx echo.Context, dbClient db.TransactionCli
 	if now_detail.Status != "approve" {
 		return api.ResGetBudgetBudgetId{}, &response.Error{Code: http.StatusInternalServerError, Level: "Error", Message: "ステータスが一致しません", Log: "Unacceptable change"}
 	}
+	if requestBody.Bought && len(now_detail.Files) == 0 {
+		return api.ResGetBudgetBudgetId{}, &response.Error{Code: http.StatusBadRequest, Level: "Error", Message: "購入済みにするには領収書を添付する必要があります", Log: "Receipt not attached"}
+	}
 	err = updateApproveBudget(dbClient, budgetId, requestBody)
 	if err != nil {
 		return api.ResGetBudgetBudgetId{}, err


### PR DESCRIPTION
承認済みの稟議を購入済みにするリクエスト時、対象の稟議に領収書の添付がなければ400を返すように