### PR TITLE
chore: MySQLをローカルのGUIクライアントから接続できるように

### DIFF
--- a/config/my.conf
+++ b/config/my.conf
@@ -1,6 +1,7 @@
 [mysqld]
 character-set-server=utf8
 secure-file-priv = ""
+bind-address = 0.0.0.0 # MySQLが外部から接続を受け入れるようにする設定
 
 [mysql]
 default-character-set=utf8

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -24,6 +24,8 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       TZ: Asia/Tokyo
+    ports:
+      - "3306:3306"
     restart: always
     networks:
       - digicoreapi
@@ -50,7 +52,6 @@ services:
 
 volumes:
   db_data:
-
 
 networks:
   https_network:


### PR DESCRIPTION
現在保護者氏名の姓名が同じフィールドに入力されていますが、大学に提出する際のフォーマットは姓名が別々のフィールドになっているため、将来的にデータベースのスキーマを変更したいです。
合わせて既存のレコードの情報を修正する必要があり、CLIだと作業が煩雑なためローカルのGUIクライアントで操作できるようにしたいと考えています。