### PR TITLE
fix: sdb.Ping()のエラーハンドリングを修正

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -27,7 +27,9 @@ func init() {
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
-	if sdb.Ping() != nil {
+
+	err = sdb.Ping()
+	if err != nil {
 		logrus.Fatal(err.Error())
 	}
 	tw = twowaysql.New(sdb)


### PR DESCRIPTION
close #222 

`sqlx.Open()`でerrが`nil`かつ`sdb.Ping()`で返り値がエラーだった場合、nilポインタ参照になってしまう問題を修正