### PR TITLE
fix: 学籍番号から学年を算出する共通処理を追加

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import "testing"
+
+func TestCalculateSchoolGrade(t *testing.T) {
+	tests := []struct {
+		name          string
+		studentNumber string
+		schoolYear    int
+		want          int
+	}{
+		{
+			name:          "通常ケース",
+			studentNumber: "aa23001",
+			schoolYear:    2025,
+			want:          3,
+		},
+		{
+			name:          "院進ケース",
+			studentNumber: "ma23001",
+			schoolYear:    2025,
+			want:          7,
+		},
+		{
+			name:          "不正フォーマットは1年生フォールバック",
+			studentNumber: "invalid",
+			schoolYear:    2025,
+			want:          1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateSchoolGrade(tt.studentNumber, tt.schoolYear)
+			if got != tt.want {
+				t.Fatalf("CalculateSchoolGrade() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
- 学籍番号から学年を算出する共通関数 CalculateSchoolGrade を pkg/utils に追加
- Google サインアップ時の初期プロフィール設定で、学年算出ロジックを共通関数へ置き換え
- 学年算出ロジックのユニットテストを追加

## 変更内容
- pkg/utils/utils.go
  - 学籍番号フォーマットを検証する正規表現を追加
  - 学籍番号から入学年度を取り出す内部関数を追加
  - 不正フォーマットや算出結果が1未満となるケースで 1 にフォールバックする処理を追加
- pkg/google_auth/post_signup_callback.go
  - サインアップ時の学年算出を utils.CalculateSchoolGrade 呼び出しに統一
- pkg/utils/utils_test.go
  - 通常ケース / 院進ケース / 不正フォーマットケースのテストを追加

## 確認
- go test ./pkg/utils を実行
  - 実行環境依存の初期化処理により dial tcp :0: connect: can't assign requested address で失敗（ロジック起因の失敗ではないことを確認）

Closes #262
