### PR TITLE
fix: 学年一括更新で共通の学年計算を使う

### DIFF
--- a/pkg/admin/put_admin_school_grade.go
+++ b/pkg/admin/put_admin_school_grade.go
@@ -6,17 +6,52 @@ import (
 	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/api"
 	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/api/response"
 	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/db"
+	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/utils"
 	"github.com/labstack/echo/v4"
 )
 
 func PutAdminSchoolGrade(_ echo.Context, dbClient db.TransactionClient) (api.BlankSuccess, *response.Error) {
-	_, err := dbClient.Exec("sql/admin/update_user_profile_school_grade.sql", nil, false)
+	targets := []struct {
+		UserId             string `db:"user_id"`
+		StudentNumber      string `db:"student_number"`
+		ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
+	}{}
+	err := dbClient.Select(&targets, "sql/admin/select_school_grade_update_targets.sql", nil)
 	if err != nil {
 		return api.BlankSuccess{}, &response.Error{
 			Code:    http.StatusInternalServerError,
 			Level:   "Error",
 			Message: "学年の更新に失敗しました",
 			Log:     err.Error(),
+		}
+	}
+
+	for _, target := range targets {
+		schoolGrade, err := utils.CalculateSchoolGradeFromStudentNumber(target.StudentNumber)
+		if err != nil {
+			return api.BlankSuccess{}, &response.Error{
+				Code:    http.StatusInternalServerError,
+				Level:   "Error",
+				Message: "学年の計算に失敗しました",
+				Log:     err.Error(),
+			}
+		}
+
+		params := struct {
+			UserId      string `twowaysql:"userId"`
+			SchoolGrade int    `twowaysql:"schoolGrade"`
+		}{
+			UserId:      target.UserId,
+			SchoolGrade: schoolGrade + target.ApprovedGradeDiffs,
+		}
+		_, err = dbClient.Exec("sql/admin/update_user_profile_school_grade.sql", &params, false)
+		if err != nil {
+			return api.BlankSuccess{}, &response.Error{
+				Code:    http.StatusInternalServerError,
+				Level:   "Error",
+				Message: "学年の更新に失敗しました",
+				Log:     err.Error(),
+			}
 		}
 	}
 

--- a/pkg/admin/put_admin_school_grade.go
+++ b/pkg/admin/put_admin_school_grade.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/api"
@@ -26,6 +27,12 @@ func PutAdminSchoolGrade(_ echo.Context, dbClient db.TransactionClient) (api.Bla
 		}
 	}
 
+	type schoolGradeUpdate struct {
+		UserId      string `json:"userId"`
+		SchoolGrade int    `json:"schoolGrade"`
+	}
+	updates := make([]schoolGradeUpdate, 0, len(targets))
+
 	for _, target := range targets {
 		schoolGrade, err := utils.CalculateSchoolGradeFromStudentNumber(target.StudentNumber)
 		if err != nil {
@@ -37,21 +44,34 @@ func PutAdminSchoolGrade(_ echo.Context, dbClient db.TransactionClient) (api.Bla
 			}
 		}
 
-		params := struct {
-			UserId      string `twowaysql:"userId"`
-			SchoolGrade int    `twowaysql:"schoolGrade"`
-		}{
+		updates = append(updates, schoolGradeUpdate{
 			UserId:      target.UserId,
 			SchoolGrade: schoolGrade + target.ApprovedGradeDiffs,
+		})
+	}
+
+	updatesJson, err := json.Marshal(updates)
+	if err != nil {
+		return api.BlankSuccess{}, &response.Error{
+			Code:    http.StatusInternalServerError,
+			Level:   "Error",
+			Message: "学年の更新に失敗しました",
+			Log:     err.Error(),
 		}
-		_, err = dbClient.Exec("sql/admin/update_user_profile_school_grade.sql", &params, false)
-		if err != nil {
-			return api.BlankSuccess{}, &response.Error{
-				Code:    http.StatusInternalServerError,
-				Level:   "Error",
-				Message: "学年の更新に失敗しました",
-				Log:     err.Error(),
-			}
+	}
+
+	params := struct {
+		UpdatesJSON string `twowaysql:"updatesJson"`
+	}{
+		UpdatesJSON: string(updatesJson),
+	}
+	_, err = dbClient.Exec("sql/admin/update_user_profile_school_grade.sql", &params, false)
+	if err != nil {
+		return api.BlankSuccess{}, &response.Error{
+			Code:    http.StatusInternalServerError,
+			Level:   "Error",
+			Message: "学年の更新に失敗しました",
+			Log:     err.Error(),
 		}
 	}
 

--- a/pkg/admin/put_admin_school_grade_test.go
+++ b/pkg/admin/put_admin_school_grade_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/SIT-DigiCre/digicore_v3_backend/pkg/utils"
 	"github.com/labstack/echo/v4"
 )
 
@@ -54,7 +55,7 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
 			}{
 				{UserId: "user-1", StudentNumber: "aa25001", ApprovedGradeDiffs: 0},
-				{UserId: "user-2", StudentNumber: "m024001", ApprovedGradeDiffs: -1},
+				{UserId: "user-2", StudentNumber: "m250001", ApprovedGradeDiffs: -1},
 			}
 			return nil
 		},
@@ -90,7 +91,9 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 	if updates[0].UserId != "user-1" || updates[0].SchoolGrade != 1 {
 		t.Fatalf("unexpected first update: %+v", updates[0])
 	}
-	if updates[1].UserId != "user-2" || updates[1].SchoolGrade != 5 {
+	currentSchoolYear := utils.GetSchoolYear()
+	expectedGraduateGrade := currentSchoolYear - 2000 - 25 + 1 + 4 - 1
+	if updates[1].UserId != "user-2" || updates[1].SchoolGrade != expectedGraduateGrade {
 		t.Fatalf("unexpected second update: %+v", updates[1])
 	}
 }

--- a/pkg/admin/put_admin_school_grade_test.go
+++ b/pkg/admin/put_admin_school_grade_test.go
@@ -1,0 +1,140 @@
+package admin
+
+import (
+	"database/sql"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+type fakeTransactionClient struct {
+	selectFunc func(dest interface{}, queryPath string, params interface{}) error
+	execFunc   func(queryPath string, params interface{}, generateId bool) (sql.Result, error)
+}
+
+func (f *fakeTransactionClient) Select(dest interface{}, queryPath string, params interface{}) error {
+	if f.selectFunc != nil {
+		return f.selectFunc(dest, queryPath, params)
+	}
+	return nil
+}
+
+func (f *fakeTransactionClient) Exec(queryPath string, params interface{}, generateId bool) (sql.Result, error) {
+	if f.execFunc != nil {
+		return f.execFunc(queryPath, params, generateId)
+	}
+	return nil, nil
+}
+
+func (f *fakeTransactionClient) GetId() (string, error) {
+	return "", nil
+}
+
+func (f *fakeTransactionClient) DuplicateUpdate(string, string, interface{}) (sql.Result, bool, error) {
+	return nil, false, nil
+}
+
+func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
+	client := &fakeTransactionClient{
+		selectFunc: func(dest interface{}, queryPath string, params interface{}) error {
+			if queryPath != "sql/admin/select_school_grade_update_targets.sql" {
+				t.Fatalf("unexpected query path: %s", queryPath)
+			}
+
+			rows := dest.(*[]struct {
+				UserId             string `db:"user_id"`
+				StudentNumber      string `db:"student_number"`
+				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
+			})
+			*rows = []struct {
+				UserId             string `db:"user_id"`
+				StudentNumber      string `db:"student_number"`
+				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
+			}{
+				{UserId: "user-1", StudentNumber: "aa25001", ApprovedGradeDiffs: 0},
+				{UserId: "user-2", StudentNumber: "m024001", ApprovedGradeDiffs: -1},
+			}
+			return nil
+		},
+	}
+
+	type updateParams struct {
+		UserId      string
+		SchoolGrade int
+	}
+	var updates []updateParams
+	client.execFunc = func(queryPath string, params interface{}, generateId bool) (sql.Result, error) {
+		if queryPath != "sql/admin/update_user_profile_school_grade.sql" {
+			t.Fatalf("unexpected query path: %s", queryPath)
+		}
+		value := reflect.ValueOf(params).Elem()
+		updates = append(updates, updateParams{
+			UserId:      value.FieldByName("UserId").String(),
+			SchoolGrade: int(value.FieldByName("SchoolGrade").Int()),
+		})
+		return nil, nil
+	}
+
+	res, err := PutAdminSchoolGrade(echo.New().NewContext(nil, nil), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Success {
+		t.Fatal("expected success response")
+	}
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+	if updates[0].UserId != "user-1" || updates[0].SchoolGrade != 1 {
+		t.Fatalf("unexpected first update: %+v", updates[0])
+	}
+	if updates[1].UserId != "user-2" || updates[1].SchoolGrade != 5 {
+		t.Fatalf("unexpected second update: %+v", updates[1])
+	}
+}
+
+func TestPutAdminSchoolGradeReturnsErrorWhenSelectFails(t *testing.T) {
+	client := &fakeTransactionClient{
+		selectFunc: func(dest interface{}, queryPath string, params interface{}) error {
+			return errors.New("select failed")
+		},
+	}
+
+	_, err := PutAdminSchoolGrade(echo.New().NewContext(nil, nil), client)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err.Message != "学年の更新に失敗しました" {
+		t.Fatalf("unexpected message: %s", err.Message)
+	}
+}
+
+func TestPutAdminSchoolGradeReturnsErrorWhenCalculationFails(t *testing.T) {
+	client := &fakeTransactionClient{
+		selectFunc: func(dest interface{}, queryPath string, params interface{}) error {
+			rows := dest.(*[]struct {
+				UserId             string `db:"user_id"`
+				StudentNumber      string `db:"student_number"`
+				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
+			})
+			*rows = []struct {
+				UserId             string `db:"user_id"`
+				StudentNumber      string `db:"student_number"`
+				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
+			}{
+				{UserId: "user-1", StudentNumber: "abxx001", ApprovedGradeDiffs: 0},
+			}
+			return nil
+		},
+	}
+
+	_, err := PutAdminSchoolGrade(echo.New().NewContext(nil, nil), client)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err.Message != "学年の計算に失敗しました" {
+		t.Fatalf("unexpected message: %s", err.Message)
+	}
+}

--- a/pkg/admin/put_admin_school_grade_test.go
+++ b/pkg/admin/put_admin_school_grade_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -71,10 +72,19 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 			t.Fatalf("unexpected query path: %s", queryPath)
 		}
 		value := reflect.ValueOf(params).Elem()
-		updates = append(updates, updateParams{
-			UserId:      value.FieldByName("UserId").String(),
-			SchoolGrade: int(value.FieldByName("SchoolGrade").Int()),
-		})
+		var rawUpdates []struct {
+			UserId      string `json:"userId"`
+			SchoolGrade int    `json:"schoolGrade"`
+		}
+		if err := json.Unmarshal([]byte(value.FieldByName("UpdatesJSON").String()), &rawUpdates); err != nil {
+			t.Fatalf("failed to unmarshal updates json: %v", err)
+		}
+		for _, update := range rawUpdates {
+			updates = append(updates, updateParams{
+				UserId:      update.UserId,
+				SchoolGrade: update.SchoolGrade,
+			})
+		}
 		return nil, nil
 	}
 
@@ -88,11 +98,18 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 	if len(updates) != 2 {
 		t.Fatalf("expected 2 updates, got %d", len(updates))
 	}
-	if updates[0].UserId != "user-1" || updates[0].SchoolGrade != 1 {
+	expectedFirstGrade, calcErr := utils.CalculateSchoolGradeFromStudentNumber("aa25001")
+	if calcErr != nil {
+		t.Fatalf("unexpected error: %v", calcErr)
+	}
+	if updates[0].UserId != "user-1" || updates[0].SchoolGrade != expectedFirstGrade {
 		t.Fatalf("unexpected first update: %+v", updates[0])
 	}
-	currentSchoolYear := utils.GetSchoolYear()
-	expectedGraduateGrade := currentSchoolYear - 2000 - 25 + 1 + 4 - 1
+	expectedGraduateGrade, calcErr := utils.CalculateSchoolGradeFromStudentNumber("m250001")
+	if calcErr != nil {
+		t.Fatalf("unexpected error: %v", calcErr)
+	}
+	expectedGraduateGrade -= 1
 	if updates[1].UserId != "user-2" || updates[1].SchoolGrade != expectedGraduateGrade {
 		t.Fatalf("unexpected second update: %+v", updates[1])
 	}

--- a/pkg/db/sql/admin/select_school_grade_update_targets.sql
+++ b/pkg/db/sql/admin/select_school_grade_update_targets.sql
@@ -1,0 +1,21 @@
+SELECT
+    BIN_TO_UUID(users.id) AS user_id,
+    users.student_number,
+    COALESCE(grade_update_summary.approved_grade_diffs, 0) AS approved_grade_diffs
+FROM user_profiles
+INNER JOIN users ON users.id = user_profiles.user_id
+LEFT JOIN (
+    SELECT
+        user_id,
+        COALESCE(SUM(grade_diff), 0) AS approved_grade_diffs
+    FROM grade_updates
+    WHERE status = 'approved'
+    GROUP BY user_id
+) AS grade_update_summary ON grade_update_summary.user_id = users.id
+WHERE user_profiles.is_graduated = false
+  AND (
+      user_profiles.is_member = true
+      OR user_profiles.school_grade < 6
+  )
+  AND CHAR_LENGTH(users.student_number) >= 4
+  AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$';

--- a/pkg/db/sql/admin/select_school_grade_update_targets.sql
+++ b/pkg/db/sql/admin/select_school_grade_update_targets.sql
@@ -17,5 +17,15 @@ WHERE user_profiles.is_graduated = false
       user_profiles.is_member = true
       OR user_profiles.school_grade < 6
   )
-  AND CHAR_LENGTH(users.student_number) >= 4
-  AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$';
+  AND (
+      (
+          LOWER(LEFT(users.student_number, 1)) IN ('m', 'n')
+          AND CHAR_LENGTH(users.student_number) >= 3
+          AND SUBSTRING(users.student_number, 2, 2) REGEXP '^[0-9]{2}$'
+      )
+      OR (
+          LOWER(LEFT(users.student_number, 1)) NOT IN ('m', 'n')
+          AND CHAR_LENGTH(users.student_number) >= 4
+          AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$'
+      )
+  );

--- a/pkg/db/sql/admin/select_school_grade_update_targets.sql
+++ b/pkg/db/sql/admin/select_school_grade_update_targets.sql
@@ -20,7 +20,7 @@ WHERE user_profiles.is_graduated = false
   AND (
       (
           LOWER(LEFT(users.student_number, 1)) IN ('m', 'n')
-          AND CHAR_LENGTH(users.student_number) >= 3
+          AND CHAR_LENGTH(users.student_number) >= 4
           AND SUBSTRING(users.student_number, 2, 2) REGEXP '^[0-9]{2}$'
       )
       OR (

--- a/pkg/db/sql/admin/update_user_profile_school_grade.sql
+++ b/pkg/db/sql/admin/update_user_profile_school_grade.sql
@@ -1,3 +1,19 @@
 UPDATE user_profiles
-SET school_grade = /*schoolGrade*/1
-WHERE user_id = UUID_TO_BIN(/*userId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+INNER JOIN (
+    SELECT
+        UUID_TO_BIN(update_rows.user_id) AS user_id,
+        update_rows.school_grade AS school_grade
+    FROM JSON_TABLE(
+        /*updatesJson*/'[]',
+        '$[*]' COLUMNS (
+            user_id CHAR(36) PATH '$.userId',
+            school_grade INT PATH '$.schoolGrade'
+        )
+    ) AS update_rows
+) AS updates ON updates.user_id = user_profiles.user_id
+SET user_profiles.school_grade = updates.school_grade
+WHERE user_profiles.is_graduated = false
+  AND (
+      user_profiles.is_member = true
+      OR user_profiles.school_grade < 6
+  );

--- a/pkg/db/sql/admin/update_user_profile_school_grade.sql
+++ b/pkg/db/sql/admin/update_user_profile_school_grade.sql
@@ -1,31 +1,3 @@
 UPDATE user_profiles
-INNER JOIN users ON users.id = user_profiles.user_id
-LEFT JOIN (
-    SELECT
-        user_id,
-        COALESCE(SUM(grade_diff), 0) AS approved_grade_diffs
-    FROM grade_updates
-    WHERE status = 'approved'
-    GROUP BY user_id
-) AS grade_update_summary ON grade_update_summary.user_id = users.id
-SET user_profiles.school_grade =
-    (
-        YEAR(CURRENT_DATE)
-        - IF(MONTH(CURRENT_DATE) BETWEEN 1 AND 3, 1, 0)
-        - 2000
-        - CAST(SUBSTRING(users.student_number, 3, 2) AS UNSIGNED)
-        + 1
-        + CASE LOWER(LEFT(users.student_number, 1))
-            WHEN 'm' THEN 4
-            WHEN 'n' THEN 6
-            ELSE 0
-          END
-        + COALESCE(grade_update_summary.approved_grade_diffs, 0)
-    )
-WHERE user_profiles.is_graduated = false
-  AND (
-      user_profiles.is_member = true
-      OR user_profiles.school_grade < 6
-  )
-  AND CHAR_LENGTH(users.student_number) >= 4
-  AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$';
+SET school_grade = /*schoolGrade*/1
+WHERE user_id = UUID_TO_BIN(/*userId*/'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -47,19 +47,24 @@ func GetAfterDate(year int, month int, day int) string {
 }
 
 func CalculateSchoolGradeFromStudentNumber(studentNumber string) (int, error) {
-	return calculateSchoolGradeFromStudentNumber(studentNumber, GetSchoolYear())
-}
-
-func calculateSchoolGradeFromStudentNumber(studentNumber string, currentSchoolYear int) (int, error) {
 	if len(studentNumber) < 4 {
 		return 0, fmt.Errorf("student number is too short: %s", studentNumber)
 	}
 
-	enterYear, err := strconv.Atoi(studentNumber[2:4])
+	enterYearText := studentNumber[2:4]
+	if len(studentNumber) >= 3 {
+		switch strings.ToLower(studentNumber[:1]) {
+		case "m", "n":
+			enterYearText = studentNumber[1:3]
+		}
+	}
+
+	enterYear, err := strconv.Atoi(enterYearText)
 	if err != nil {
 		return 0, fmt.Errorf("student number has invalid enter year: %s: %w", studentNumber, err)
 	}
 
+	currentSchoolYear := GetSchoolYear()
 	schoolGrade := currentSchoolYear - 2000 - enterYear + 1
 	switch strings.ToLower(studentNumber[:1]) {
 	case "m":

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -52,11 +52,9 @@ func CalculateSchoolGradeFromStudentNumber(studentNumber string) (int, error) {
 	}
 
 	enterYearText := studentNumber[2:4]
-	if len(studentNumber) >= 3 {
-		switch strings.ToLower(studentNumber[:1]) {
-		case "m", "n":
-			enterYearText = studentNumber[1:3]
-		}
+	switch strings.ToLower(studentNumber[:1]) {
+	case "m", "n":
+		enterYearText = studentNumber[1:3]
 	}
 
 	enterYear, err := strconv.Atoi(enterYearText)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -47,11 +47,14 @@ func GetAfterDate(year int, month int, day int) string {
 }
 
 func CalculateSchoolGradeFromStudentNumber(studentNumber string) (int, error) {
+	return calculateSchoolGradeFromStudentNumber(studentNumber, GetSchoolYear())
+}
+
+func calculateSchoolGradeFromStudentNumber(studentNumber string, currentSchoolYear int) (int, error) {
 	if len(studentNumber) < 4 {
 		return 0, fmt.Errorf("student number is too short: %s", studentNumber)
 	}
 
-	currentSchoolYear := GetSchoolYear()
 	enterYear, err := strconv.Atoi(studentNumber[2:4])
 	if err != nil {
 		return 0, fmt.Errorf("student number has invalid enter year: %s: %w", studentNumber, err)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,54 +3,53 @@ package utils
 import "testing"
 
 func TestCalculateSchoolGradeFromStudentNumber(t *testing.T) {
+	currentSchoolYear := GetSchoolYear()
 	tests := []struct {
-		name              string
-		studentNumber     string
-		currentSchoolYear int
-		expected          int
-		expectErr         bool
+		name          string
+		studentNumber string
+		expected      int
+		expectErr     bool
 	}{
 		{
-			name:              "学部生の学年を計算できる",
-			studentNumber:     "aa25001",
-			currentSchoolYear: 2025,
-			expected:          1,
+			name:          "学部生の学年を計算できる",
+			studentNumber: "aa25001",
+			expected:      currentSchoolYear - 2000 - 25 + 1,
 		},
 		{
-			name:              "大学院修士は 4 年加算する",
-			studentNumber:     "m025001",
-			currentSchoolYear: 2025,
-			expected:          5,
+			name:          "大学院修士は 4 年加算する",
+			studentNumber: "m250001",
+			expected:      currentSchoolYear - 2000 - 25 + 1 + 4,
 		},
 		{
-			name:              "大学院博士は 6 年加算する",
-			studentNumber:     "N025001",
-			currentSchoolYear: 2025,
-			expected:          7,
+			name:          "大学院博士は 6 年加算する",
+			studentNumber: "N250001",
+			expected:      currentSchoolYear - 2000 - 25 + 1 + 6,
 		},
 		{
-			name:              "古い入学年度でも負数エラーにならず計算できる",
-			studentNumber:     "aa99001",
-			currentSchoolYear: 2025,
-			expected:          -73,
+			name:          "古い入学年度でも負数エラーにならず計算できる",
+			studentNumber: "aa99001",
+			expected:      currentSchoolYear - 2000 - 99 + 1,
 		},
 		{
-			name:              "学籍番号が短すぎるとエラー",
-			studentNumber:     "a25",
-			currentSchoolYear: 2025,
-			expectErr:         true,
+			name:          "学籍番号が短すぎるとエラー",
+			studentNumber: "a25",
+			expectErr:     true,
 		},
 		{
-			name:              "入学年度が数値でないとエラー",
-			studentNumber:     "aaxx001",
-			currentSchoolYear: 2025,
-			expectErr:         true,
+			name:          "入学年度が数値でないとエラー",
+			studentNumber: "aaxx001",
+			expectErr:     true,
+		},
+		{
+			name:          "大学院生の入学年度が数値でないとエラー",
+			studentNumber: "mxx0001",
+			expectErr:     true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := calculateSchoolGradeFromStudentNumber(tc.studentNumber, tc.currentSchoolYear)
+			actual, err := CalculateSchoolGradeFromStudentNumber(tc.studentNumber)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatal("expected error but got nil")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import "testing"
+
+func TestCalculateSchoolGradeFromStudentNumber(t *testing.T) {
+	tests := []struct {
+		name              string
+		studentNumber     string
+		currentSchoolYear int
+		expected          int
+		expectErr         bool
+	}{
+		{
+			name:              "学部生の学年を計算できる",
+			studentNumber:     "aa25001",
+			currentSchoolYear: 2025,
+			expected:          1,
+		},
+		{
+			name:              "大学院修士は 4 年加算する",
+			studentNumber:     "m025001",
+			currentSchoolYear: 2025,
+			expected:          5,
+		},
+		{
+			name:              "大学院博士は 6 年加算する",
+			studentNumber:     "N025001",
+			currentSchoolYear: 2025,
+			expected:          7,
+		},
+		{
+			name:              "古い入学年度でも負数エラーにならず計算できる",
+			studentNumber:     "aa99001",
+			currentSchoolYear: 2025,
+			expected:          -73,
+		},
+		{
+			name:              "学籍番号が短すぎるとエラー",
+			studentNumber:     "a25",
+			currentSchoolYear: 2025,
+			expectErr:         true,
+		},
+		{
+			name:              "入学年度が数値でないとエラー",
+			studentNumber:     "aaxx001",
+			currentSchoolYear: 2025,
+			expectErr:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := calculateSchoolGradeFromStudentNumber(tc.studentNumber, tc.currentSchoolYear)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expected {
+				t.Fatalf("expected %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
- issue 309 の学年一括更新エラーを修正
- `/admin/school-grade` で学年計算を Go の共通ロジックに統一
- 対象抽出 SQL と学年計算テストを追加

## 動作確認
- `set -a && source .env && set +a && DB_HOST=127.0.0.1 GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod GOPATH=/tmp/go go test ./pkg/utils ./pkg/admin`

Closes #309