### PR TITLE
fix: 大学院生の学年計算ロジックを修正

### DIFF
--- a/pkg/admin/put_admin_school_grade_test.go
+++ b/pkg/admin/put_admin_school_grade_test.go
@@ -56,7 +56,7 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 				ApprovedGradeDiffs int    `db:"approved_grade_diffs"`
 			}{
 				{UserId: "user-1", StudentNumber: "aa25001", ApprovedGradeDiffs: 0},
-				{UserId: "user-2", StudentNumber: "m250001", ApprovedGradeDiffs: -1},
+				{UserId: "user-2", StudentNumber: "ma25001", ApprovedGradeDiffs: -1},
 			}
 			return nil
 		},
@@ -105,7 +105,7 @@ func TestPutAdminSchoolGradeUpdatesEachTarget(t *testing.T) {
 	if updates[0].UserId != "user-1" || updates[0].SchoolGrade != expectedFirstGrade {
 		t.Fatalf("unexpected first update: %+v", updates[0])
 	}
-	expectedGraduateGrade, calcErr := utils.CalculateSchoolGradeFromStudentNumber("m250001")
+	expectedGraduateGrade, calcErr := utils.CalculateSchoolGradeFromStudentNumber("ma25001")
 	if calcErr != nil {
 		t.Fatalf("unexpected error: %v", calcErr)
 	}

--- a/pkg/db/sql/admin/select_school_grade_update_targets.sql
+++ b/pkg/db/sql/admin/select_school_grade_update_targets.sql
@@ -15,17 +15,9 @@ LEFT JOIN (
 WHERE user_profiles.is_graduated = false
   AND (
       user_profiles.is_member = true
-      OR user_profiles.school_grade < 6
+      OR user_profiles.school_grade < 4
   )
   AND (
-      (
-          LOWER(LEFT(users.student_number, 1)) IN ('m', 'n')
-          AND CHAR_LENGTH(users.student_number) >= 4
-          AND SUBSTRING(users.student_number, 2, 2) REGEXP '^[0-9]{2}$'
-      )
-      OR (
-          LOWER(LEFT(users.student_number, 1)) NOT IN ('m', 'n')
-          AND CHAR_LENGTH(users.student_number) >= 4
-          AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$'
-      )
+      CHAR_LENGTH(users.student_number) >= 4
+      AND SUBSTRING(users.student_number, 3, 2) REGEXP '^[0-9]{2}$'
   );

--- a/pkg/db/sql/admin/update_user_profile_school_grade.sql
+++ b/pkg/db/sql/admin/update_user_profile_school_grade.sql
@@ -15,5 +15,5 @@ SET user_profiles.school_grade = updates.school_grade
 WHERE user_profiles.is_graduated = false
   AND (
       user_profiles.is_member = true
-      OR user_profiles.school_grade < 6
+      OR user_profiles.school_grade < 4
   );

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -52,10 +52,6 @@ func CalculateSchoolGradeFromStudentNumber(studentNumber string) (int, error) {
 	}
 
 	enterYearText := studentNumber[2:4]
-	switch strings.ToLower(studentNumber[:1]) {
-	case "m", "n":
-		enterYearText = studentNumber[1:3]
-	}
 
 	enterYear, err := strconv.Atoi(enterYearText)
 	if err != nil {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -17,12 +17,12 @@ func TestCalculateSchoolGradeFromStudentNumber(t *testing.T) {
 		},
 		{
 			name:          "大学院修士は 4 年加算する",
-			studentNumber: "m250001",
+			studentNumber: "ma25001",
 			expected:      currentSchoolYear - 2000 - 25 + 1 + 4,
 		},
 		{
 			name:          "大学院博士は 6 年加算する",
-			studentNumber: "N250001",
+			studentNumber: "na25001",
 			expected:      currentSchoolYear - 2000 - 25 + 1 + 6,
 		},
 		{


### PR DESCRIPTION
#340 で漏れていた点を修正

- SQLで学籍番号が`m`・`n`から始まるかつ2~3文字目が数字でない人が更新対象から除外されていた。`m`・`n`の条件分岐を廃止した。
- `is_member=false`の場合もM2までは学年が更新されていた。B4までに変更した。